### PR TITLE
fix: add sonar and change the dependabot.yaml file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,17 +9,52 @@ updates:
     reviewers:
       - "openkcm/go-maintainers"
     schedule:
-      interval: daily
+      interval: weekly
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    groups:
+      gomod-group:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5
   - package-ecosystem: docker
     directory: /
     reviewers:
       - "openkcm/go-maintainers"
     schedule:
-      interval: daily
+      interval: weekly
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    groups:
+      docker-group:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     reviewers:
       - "openkcm/go-maintainers"
     schedule:
-      interval: "daily"
+      interval: weekly
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    groups:
+      actions-group:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,16 @@
+name: Sonar Analysis Secure
+
+on:
+  workflow_run:
+    workflows: ["Quality"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  check:
+    uses: openkcm/build/.github/workflows/sonar.yaml@main
+    secrets: inherit


### PR DESCRIPTION
# Add SonarQube Analysis Workflow and Update Dependabot Configuration

### Chore

🔧 Added a SonarQube analysis workflow and updated the Dependabot configuration to improve update scheduling and grouping across all package ecosystems.

### Changes

* `.github/workflows/sonar.yaml`: Added a new secure SonarQube analysis workflow that triggers on completion of the `Quality` workflow. It reuses a shared workflow from `openkcm/build` with inherited secrets.

* `.github/dependabot.yaml`: Updated all three package ecosystems (`gomod`, `docker`, `github-actions`) with the following changes:
  - Changed update interval from `daily` to `weekly` for all ecosystems.
  - Added `commit-message` configuration with `fix` prefix and scope.
  - Added dependency grouping for minor and patch version updates.
  - Added `open-pull-requests-limit: 5` for the `docker` and `github-actions` ecosystems.
  - Fixed indentation issues throughout the file.

- [ ] 🔄 Regenerate and Update Summary